### PR TITLE
Fix 'install should not be an array' PKGBUILD error

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,7 +12,6 @@ depends=('libvterm-bzr')
 makedepends=('bzr' 'libvterm-bzr')
 provides=("${pkgname%-bzr}")
 conflicts=("${pkgname%-bzr}")
-install=('pangoterm.install')
 source=("bzr+http://bazaar.leonerd.org.uk/code/pangoterm/")
 sha256sums=('SKIP')
 


### PR DESCRIPTION
Hi! Pangoterm seems great.
With a fresh Arch installation I tried building this package, and encountered this error:
``` sh
> makepkg -sri
==> ERROR: install should not be an array
```

I hunted down this being an issue in `PKGBUILD`. [This thread](https://bbs.archlinux.org/viewtopic.php?pid=1602873#p1602873) suggests new checks in pacman 5 are to blame. This patch resolves the problem by removing the unnecessary brackets.

I haven't tested this with pacman 4, if you could that might be useful.

Cheers!